### PR TITLE
Replace Filebeat ingestion guide with Fluent Bit instructions

### DIFF
--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-gb.md
@@ -1,322 +1,164 @@
 ---
-title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-11-28
+title: Pushing logs with a forwarder - Fluent Bit (Linux)
+updated: 2025-03-14
 ---
 
 ## Objective
 
-[Filebeat](https://github.com/elastic/beats/tree/master/filebeat) is an open source file harvester, used to fetch logs files and can be easily setup to feed them into Logs Data Platform.
+[Fluent Bit](https://fluentbit.io/) is a lightweight and high-performance log processor able to collect data from many sources and send it to numerous outputs, including OpenSearch. This guide explains how to replace Filebeat with Fluent Bit in order to forward **system** and **Apache HTTP Server (apache2)** logs to Logs Data Platform by using a single OpenSearch output.
 
-The main benefits of Filebeat are its resilient protocol to send logs, and a variety of ready-to-use modules for most of the common applications.
-
-This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+The tutorial focuses on Debian/Ubuntu-based systems but can be adapted to other Linux distributions.
 
 ## Requirements
 
-Note that in order to complete this tutorial, you should have at least:
+To complete this tutorial, you need:
 
-- [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29)
-- [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- An active [Logs Data Platform account](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29)).
+- A stream created in Logs Data Platform with its [IAM bearer token ready](/pages/manage_and_operate/observability/logs_data_platform/security_tokens/guide.en-gb/#generating-tokens-with-iam). Fluent Bit will authenticate to OpenSearch with this token instead of username/password credentials.
+- Root or sudo access on the machine that will run Fluent Bit.
 
 ## Instructions
 
-### Setup Filebeat OSS 7.X in your system
+### 1. Install the latest Fluent Bit release
 
-Filebeat supports many platforms as listed here [https://www.elastic.co/downloads/beats/filebeat](https://www.elastic.co/downloads/beats/filebeat)
+At the time of writing, the current stable version of Fluent Bit is **3.0.4**. Use the official packages to ensure you receive the latest binaries and dependencies.
 
-You can decide to setup Filebeat OSS from a package or to compile it from source (you will need the latest [go compiler](https://golang.org/) to compile it) or just download the binary to start immediately.
+```bash
+curl https://packages.fluentbit.io/fluentbit.key | sudo gpg --dearmor -o /usr/share/keyrings/fluentbit-keyring.gpg
 
-For this part, head to [Filebeat OSS download website](https://www.elastic.co/fr/downloads/past-releases#filebeat-oss) to download the best version for your distribution.
+echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/debian/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/fluent-bit.list
 
-The following configuration files have been tested on the latest version of Filebeat OSS compatible with OpenSearch (**7.12.1**).
+sudo apt update
+sudo apt install fluent-bit
+```
 
-The package will install the config file in the following directory: `/etc/filebeat/filebeat.yml`.
+> [!primary]
+> Adapt the repository URL if you are not using a Debian-based system. RPM packages and tar archives are available on the [Fluent Bit downloads page](https://fluentbit.io/download/).
+
+### 2. Create the Fluent Bit configuration
+
+We will collect two distinct sources:
+
+- **System logs** from the local systemd journal using the `systemd` input.
+- **Apache HTTP Server logs** (`access.log` and `error.log`) using the `tail` input.
+
+Both streams will be enriched with common fields (service name, environment) and sent to OpenSearch through a single `opensearch` output configured to use your IAM bearer token.
+
+Create `/etc/fluent-bit/fluent-bit.conf` with the following content:
+
+```ini
+[SERVICE]
+    Flush        5
+    Daemon       Off
+    Log_Level    info
+    Parsers_File parsers.conf
+
+[INPUT]
+    Name              systemd
+    Tag               systemd.*
+    Read_From_Tail    On
+
+[INPUT]
+    Name              tail
+    Tag               apache.*
+    Path              /var/log/apache2/access.log,/var/log/apache2/error.log
+    Path_Key          log_file
+    Refresh_Interval  10
+    Skip_Long_Lines   On
+    DB                /var/lib/fluent-bit/apache2.db
+    Parser            apache2
+
+[FILTER]
+    Name          modify
+    Match         systemd.*
+    Add           service_type system
+    Add           environment  production
+
+[FILTER]
+    Name          modify
+    Match         apache.*
+    Add           service_type apache2
+    Add           environment  production
+
+[OUTPUT]
+    Name            opensearch
+    Match           *
+    Host            <your_cluster>.logs.ovh.com
+    Port            9200
+    Logstash_Format On
+    Logstash_Prefix ${LD_STREAM_ID}-fluentbit
+    Replace_Dots    On
+    Header          Authorization Bearer ${IAM_BEARER_TOKEN}
+    tls             On
+    tls.verify      On
+```
+
+Replace the placeholders as follows:
+
+- `<your_cluster>.logs.ovh.com`: the endpoint provided by Logs Data Platform for your OpenSearch cluster.
+- `${LD_STREAM_ID}`: the identifier of your target stream. For example, `ld-1234567890`.
+- `${IAM_BEARER_TOKEN}`: the IAM bearer token value generated for that stream (see the [Security Tokens guide](/pages/manage_and_operate/observability/logs_data_platform/security_tokens/guide.en-gb/#generating-tokens-with-iam)). You can export it as an environment variable prior to starting Fluent Bit, or replace the variable with the raw token string.
+
+The output section relies on the OpenSearch plugin. The `Header` directive injects the IAM bearer token as a standard `Authorization: Bearer` header, which is the authentication method described in the Security Tokens guide. With `Logstash_Format On`, Fluent Bit appends the current date to the index name; `Logstash_Prefix` ensures each daily index starts with your stream identifier (for example, `ld-1234567890-fluentbit-2025.03.14`).
 
 > [!warning]
-> Do not use a version superior than the 7.12 version. They are currently not compatible with OpenSearch.
-> More information in the [matrix compatibility documentation](https://opensearch.org/docs/latest/clients/agents-and-ingestion-tools/index/#compatibility-matrix-for-beats).
+> Make sure the token you generated has the `PUSH` permission on the stream, otherwise Fluent Bit will receive HTTP 403 errors.
 
-### Configure Filebeat OSS 7.X on your system
+### 3. Define the Apache log parser
 
-In the following example we will enable Apache and Syslog support, but you can easily prospect [anything else](https://www.elastic.co/guide/en/beats/filebeat/7.12/filebeat-modules.html).
+Fluent Bit’s default configuration file includes common parsers, but we explicitly add one tailored for the Apache combined log format.
 
-Filebeat expects a configuration file named **filebeat.yml** .
+Create `/etc/fluent-bit/parsers.conf` with:
 
-1. For the configuration to work, it is mandatory to replace hosts: ["`<your_cluster>.logs.ovh.com:5044`"] with the hostname given by Logs Data Platform.
-2. You should also ensure to specify the `X-OVH-TOKEN` of the related stream.
-
-#### Filebeat configuration
-
-```yaml
-###################### Filebeat Configuration Example #########################
-
-# This file is an example configuration file highlighting only the most common
-# options. The filebeat.reference.yml file from the same directory contains all the
-# supported options with more comments. You can use it as a reference.
-#
-# You can find the full configuration reference here:
-# https://www.elastic.co/guide/en/beats/filebeat/index.html
-
-# For more available modules and options, please see the filebeat.reference.yml sample
-# configuration file.
-
-#=========================== Filebeat inputs =============================
-
-filebeat.inputs:
-
-# Each - is an input. Most options can be set at the input level, so
-# you can use different inputs for various configurations.
-# Below are the input specific configurations.
-
-- type: log
-
-  # Change to true to enable this input configuration.
-  enabled: false
-
-  # Paths that should be crawled and fetched. Glob based paths.
-  paths:
-    - /var/log/*.log
-    #- c:\programdata\elasticsearch\logs\*
-
-  # Exclude lines. A list of regular expressions to match. It drops the lines that are
-  # matching any regular expression from the list.
-  #exclude_lines: ['^DBG']
-
-  # Include lines. A list of regular expressions to match. It exports the lines that are
-  # matching any regular expression from the list.
-  #include_lines: ['^ERR', '^WARN']
-
-  # Exclude files. A list of regular expressions to match. Filebeat drops the files that
-  # are matching any regular expression from the list. By default, no files are dropped.
-  #exclude_files: ['.gz$']
-
-  # Optional additional fields. These fields can be freely picked
-  # to add additional information to the crawled log files for filtering
-  #fields:
-  #  level: debug
-  #  review: 1
-
-  ### Multiline options
-
-  # Multiline can be used for log messages spanning multiple lines. This is common
-  # for Java Stack Traces or C-Line Continuation
-
-  # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
-  #multiline.pattern: ^\[
-
-  # Defines if the pattern set under pattern should be negated or not. Default is false.
-  #multiline.negate: false
-
-  # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
-  # that was (not) matched before or after or as long as a pattern is not matched based on negate.
-  # Note: After is the equivalent to previous and before is the equivalent to next in Logstash
-  #multiline.match: after
-
-#============================= Filebeat modules ===============================
-
-filebeat.config.modules:
-  # Glob pattern for configuration loading
-  path: ${path.config}/modules.d/*.yml
-
-  # Set to true to enable config reloading
-  reload.enabled: false
-
-  # Period on which files under path should be checked for changes
-  #reload.period: 10s
-
-#================================ General =====================================
-
-# The name of the shipper that publishes the network data. It can be used to group
-# all the transactions sent by a single shipper in the web interface.
-#name:
-
-# The tags of the shipper are included in their own field with each
-# transaction published.
-#tags: ["service-X", "web-tier"]
-
-# Optional fields that you can specify to add additional information to the
-# output.
-fields_under_root: true
-fields:
-  X-OVH-TOKEN: 'xxxxxxxxxxxxxxxxxxxxx'
-
-#================================ Outputs =====================================
-
-# Configure what output to use when sending the data collected by the beat.
-
-#----------------------------- Logstash output --------------------------------
-output.logstash:
-  # Boolean flag to enable or disable the output module.
-  enabled: true
-
-  # The Logstash hosts
-  hosts: ["<your_cluster>.logs.ovh.com:5044"]
-
-  # Set gzip compression level.
-  compression_level: 3
-
-  # Enable SSL support. SSL is automatically enabled if any SSL setting is set.
-  ssl.enabled: true
-
-  # Optional SSL configuration options. SSL is off by default.
-  # List of root certificates for HTTPS server verifications
-  # ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
-
-#================================ Processors =====================================
-
-# Configure processors to enhance or manipulate events generated by the beat.
-
-processors:
-  - add_host_metadata: ~
-  - add_cloud_metadata: ~
-
-#================================ Logging =====================================
-
-# Sets log level. The default log level is info.
-# Available log levels are: error, warning, info, debug
-#logging.level: debug
-
-# At debug level, you can selectively enable logging only for some components.
-# To enable all selectors use ["*"]. Examples of other selectors are "beat",
-# "publish", "service".
-#logging.selectors: ["*"]
+```ini
+[PARSER]
+    Name        apache2
+    Format      regex
+    Regex       ^(?<remote_host>[^ ]*) (?<remote_logname>[^ ]*) (?<remote_user>[^ ]*) \[(?<time_local>[^\]]*)\] "(?<request>[^"\\]*(?:\\.[^"\\]*)*)" (?<status>\d{3}) (?<body_bytes_sent>[^ ]*) "(?<http_referer>[^"\\]*(?:\\.[^"\\]*)*)" "(?<http_user_agent>[^"\\]*(?:\\.[^"\\]*)*)"
+    Time_Key    time_local
+    Time_Format %d/%b/%Y:%H:%M:%S %z
 ```
 
-You can also use our [OpenSearch endpoint](/pages/manage_and_operate/observability/logs_data_platform/ingestion_opensearch_api_mutualized_input) to send your logs. This endpoint support ingest and then ensures a higher performance and a higher compatibility with the modules selected. For legal reasons, we do not support X-Pack modules on this endpoint but any OSS module is supported. To enable this endpoint, replace the Logstash Output configuration with the following snippet:
+If your Apache logs use the default combined format, this parser will extract the usual fields. Adjust the regular expression if you customized the log format.
 
-```yaml
-#==================== Output template setting ==========================
+### 4. Provide the IAM bearer token to Fluent Bit
 
-setup.template.enabled: false
-setup.ilm.enabled: false
+Export the token as an environment variable before starting the service:
 
-#-------------------------- OpenSearch output ------------------------------
-output.elasticsearch:
-  # Array of hosts to connect to.
-  hosts: ["<your-cluster>.logs.ovh.com:9200"]
-
-  # Protocol - either `http` (default) or `https`.
-  protocol: "https"
-
-  # Authentication credentials - either API key or username/password.
-  username: "<username>"
-  password: "<password>"
-  index: "ldp-logs"
-  # Header for OpenSearch 2.X
-  headers:
-    X-Es-Compat: "7.10"
-
+```bash
+export IAM_BEARER_TOKEN="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+export LD_STREAM_ID="ld-1234567890"
 ```
 
-> [!warning]
->
-> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
->
+You can also set these variables permanently in `/etc/default/fluent-bit` (Debian/Ubuntu) so that they are available to the systemd unit.
 
+### 5. Test the configuration interactively
 
-This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
+Before enabling the service, run Fluent Bit in the foreground to confirm that records are sent correctly:
 
-When you use our OpenSearch endpoint with filebeat, it will use the [ingest module](https://www.elastic.co/guide/en/logstash/7.12/use-ingest-pipelines.html) to parse and structure the logs.
-
-#### Enable Apache Filebeat module
-
-To enable the apache2 support on Filebeat, call the following command:
-
-```shell-session
-$ ldp@ubuntu:~$ sudo filebeat modules enable apache
+```bash
+sudo -E fluent-bit -c /etc/fluent-bit/fluent-bit.conf
 ```
 
-It will generate a new module file: **/etc/filebeat/modules.d/apache.yml**, please change it to include all your apache2 access/error path files:
+Keep the `sudo -E` flag so that the environment variables are preserved. Send a few Apache requests (for example with `curl http://localhost/`) and check that Fluent Bit prints successful delivery messages. Use `Ctrl+C` to stop the test run.
 
-```yaml
-- module: apache
-  # Access logs
-  access:
-    enabled: true
+### 6. Enable Fluent Bit as a service
 
-    # Set custom paths for the log files. If left empty,
-    # Filebeat will choose the paths depending on your OS.
-    var.paths: ["/var/log/apache2/access.log*","/var/log/apache2/ssl_access.log*"]
+Once the configuration is validated, enable and start Fluent Bit with systemd:
 
-  # Error logs
-  error:
-    enabled: true
-
-    # Set custom paths for the log files. If left empty,
-    # Filebeat will choose the paths depending on your OS.
-    var.paths: ["/var/LOG/apache2/error_log*","/var/log/apache2/ssl_error_log*"]
+```bash
+sudo systemctl enable fluent-bit
+sudo systemctl start fluent-bit
+sudo systemctl status fluent-bit
 ```
 
-#### Enable System Filebeat module
+The status command should report `active (running)`. Check `/var/log/syslog` or `journalctl -u fluent-bit` if you encounter issues.
 
-Syslog and authentication supports are part of the system Filebeat module, to enable it:
+## Troubleshooting tips
 
-```shell-session
-$ ldp@ubuntu:~$ sudo filebeat modules enable system
-```
+- **Authentication errors (403)**: Regenerate the IAM bearer token with the correct scope (`PUSH` permission) and make sure it matches the stream referenced by `Logstash_Prefix`.
+- **Index naming**: Fluent Bit does not automatically create streams. Ensure the `Logstash_Prefix` matches the naming convention expected by Logs Data Platform. If you need multiple environments, create separate streams and adjust the prefix accordingly.
+- **Apache permissions**: Fluent Bit must be able to read `/var/log/apache2/*.log`. If the service runs under the `fluent-bit` user, add it to the `adm` group on Debian/Ubuntu (`sudo usermod -a -G adm fluent-bit`).
+- **Systemd input volume**: Add `Systemd_Filter` directives if you want to limit Fluent Bit to specific units (for example, `Systemd_Filter _SYSTEMD_UNIT=ssh.service`). Collecting the full journal can generate a high volume of events on busy hosts.
 
-Once again, it will generate a file **/etc/filebeat/modules.d/system.yml**
-
-```yaml
-- module: system
-  # Syslog
-  syslog:
-    enabled: true
-
-    # Set custom paths for the log files. If left empty,
-    # Filebeat will choose the paths depending on your OS.
-    var.paths: ["/var/log/syslog*"]
-
-  # Authorization logs
-  auth:
-    enabled: true
-
-    # Set custom paths for the log files. If left empty,
-    # Filebeat will choose the paths depending on your OS.
-    var.paths: ["/var/log/auth.log*"]
-```
-
-Ensure both file path exists on your system.
-
-#### Enable pipelines
-
-If you use the "Elasticsearch output", be sure to setup the pipelines by using the following command:
-
-```shell-session
-$ filebeat setup --pipelines --modules apache,system
-```
-
-Filebeat will then connect to OpenSearch and setup the pipelines needed by your modules.
-
-#### Launch Filebeat
-
-Launch the Filebeat binary or service to test your config file and head to your apache website for an example of how to send some logs. You will see this kind of log in Graylog:
-
-```shell-session
-$ ldp@ubuntu:~$ sudo systemctl restart filebeat.service
-```
-
-or
-
-```shell-session
-$ ldp@ubuntu:~$ sudo /etc/init.d/filebeat restart
-```
-
-![beat_graylog](images/beats_graylog.png){.thumbnail}
-
-Note the type value (apache or syslog or apache-error) that indicates the source file of the log message. You can easily display only your apache access logs for example by typing in the search bar **fileset_module:apache2**.
-
-### Conclusion and useful resources
-
-Filebeat is a handy tool to send the content of your current log files to Logs Data Platform. It offers a clean and easy way to send your logs without changing the configuration of your software. Don't hesitate to check the links below to master this tool.
-
-- Configuration's details: [https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration-details.html](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration-details.html)
-- Getting started: [https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-getting-started.html](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-getting-started.html)
-- Learn how to configure Filebeat and Logstash to add your own extra filters: [Dedicated input - Logstash](/pages/manage_and_operate/observability/logs_data_platform/ingestion_logstash_dedicated_input)
-
-## Going further
-
-- Getting Started: [Quick Start](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
-- Documentation: [Guides](/products/observability-logs-data-platform)
-- Community hub: [https://community.ovh.com](https://community.ovh.com/en/c/Platform/data-platforms)
-- Create an account: [Try it!](/links/manage-operate/ldp)
+Fluent Bit now forwards both system and Apache logs to Logs Data Platform using the IAM bearer token-based authentication mechanism.


### PR DESCRIPTION
## Summary
- rewrite the Linux ingestion guide to focus on Fluent Bit instead of Filebeat
- document installation, configuration, and token usage for forwarding system and Apache logs via IAM bearer tokens
- provide ready-to-use Fluent Bit and parser configuration examples plus troubleshooting guidance

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68e908f299a0832688f3a00aac69cf93